### PR TITLE
Theta argument in pgun_lcio has at most two arguments.

### DIFF
--- a/generation/pgun/pgun_lcio.py
+++ b/generation/pgun/pgun_lcio.py
@@ -23,7 +23,7 @@ parser.add_argument('--dz', metavar='V', type=float, nargs='*', default=0,  help
 parser.add_argument('--d0', metavar='V', type=float, nargs='*', default=0,  help='Vertex position along R [mm]')
 parser.add_argument('--pt', metavar='V', type=float, nargs='*',  help='Tranverse momentum [GeV]')
 parser.add_argument('--p', metavar='V', type=float, nargs='*',  help='Total momentum [GeV]')
-parser.add_argument('--theta', metavar='A', type=float, default=90, nargs='+',  help='Polar angle [deg]')
+parser.add_argument('--theta', metavar='A', type=float, default=90, nargs=2,  help='Polar angle [deg]')
 
 args = parser.parse_args()
 


### PR DESCRIPTION
Changes the `nargs` from `"+"` to `2` for the theta argument of the `pgun_lcio.py` script to indicate that the minimum and maximum should be supplied. It does not seem make sense to supply more.

Also having an undefined number of options causes an error if you put the output file as the last argument.