### PR TITLE
Make the output file names more explicit with their type.

### DIFF
--- a/digitisation/marlin/digi_steer.xml
+++ b/digitisation/marlin/digi_steer.xml
@@ -95,7 +95,7 @@
     <!-- compression of output file 0: false >0: true (default) -->
     <parameter name="Compress" type="int" value="1"/>
     <!-- filename (without extension) -->
-    <parameter name="FileName" type="string" value="out_processors"/>
+    <parameter name="FileName" type="string" value="output_digi"/>
     <!-- type of output file xml (default) or root ( only OpenScientist) -->
     <parameter name="FileType" type="string" value="root "/>
   </processor>

--- a/digitisation/marlin/digi_steer.xml
+++ b/digitisation/marlin/digi_steer.xml
@@ -107,7 +107,7 @@
 
   <!-- LCIO output: keep all collections -->
   <processor name="LCIOWriter_all" type="LCIOOutputProcessor">
-    <parameter name="LCIOOutputFile" type="string"> out.slcio </parameter>
+    <parameter name="LCIOOutputFile" type="string"> output_digi.slcio </parameter>
     <parameter name="FullSubsetCollections" type="StringVec">  </parameter>
     <parameter name="DropCollectionTypes" type="StringVec">  </parameter>
     <parameter name="DropCollectionNames" type="StringVec">  </parameter>
@@ -119,7 +119,7 @@
 
   <!-- LCIO output: keep only collections relevant for analysis -->
   <processor name="LCIOWriter_light" type="LCIOOutputProcessor">
-    <parameter name="LCIOOutputFile" type="string"> out_light.slcio </parameter>
+    <parameter name="LCIOOutputFile" type="string"> output_digi_light.slcio </parameter>
     <parameter name="FullSubsetCollections" type="StringVec"> </parameter>
     <!-- Removing SimHits, MCParticles and all the relation info -->
     <parameter name="DropCollectionTypes" type="StringVec">

--- a/reconstruction/marlin/reco_steer.xml
+++ b/reconstruction/marlin/reco_steer.xml
@@ -72,7 +72,7 @@
     <!-- compression of output file 0: false >0: true (default) -->
     <parameter name="Compress" type="int" value="1"/>
     <!-- filename (without extension) -->
-    <parameter name="FileName" type="string" value="out_processors"/>
+    <parameter name="FileName" type="string" value="output_reco"/>
     <!-- type of output file xml (default) or root ( only OpenScientist) -->
     <parameter name="FileType" type="string" value="root "/>
   </processor>

--- a/reconstruction/marlin/reco_steer.xml
+++ b/reconstruction/marlin/reco_steer.xml
@@ -84,7 +84,7 @@
 
   <!-- LCIO output: keep all collections -->
   <processor name="LCIOWriter_all" type="LCIOOutputProcessor">
-    <parameter name="LCIOOutputFile" type="string"> out.slcio </parameter>
+    <parameter name="LCIOOutputFile" type="string"> output_reco.slcio </parameter>
     <parameter name="FullSubsetCollections" type="StringVec">  </parameter>
     <parameter name="DropCollectionTypes" type="StringVec">  </parameter>
     <parameter name="DropCollectionNames" type="StringVec">  </parameter>
@@ -96,7 +96,7 @@
 
   <!-- LCIO output: keep only collections relevant for analysis -->
   <processor name="LCIOWriter_light" type="LCIOOutputProcessor">
-    <parameter name="LCIOOutputFile" type="string"> out_light.slcio </parameter>
+    <parameter name="LCIOOutputFile" type="string"> output_reco_light.slcio </parameter>
     <parameter name="FullSubsetCollections" type="StringVec"> </parameter>
     <!-- Removing SimHits, MCParticles and all the relation info -->
     <parameter name="DropCollectionTypes" type="StringVec">


### PR DESCRIPTION
The outputs are now `output_digi.slcio` and `output_reco.slcio` (similarly for the light versions). This makes them consistent with the simulation configuration. Also it prevents files being overwritten when not explicitly specifying an output file name.