### PR TITLE
Steer DD4hepXMLFile with MUCOLL_GEO?

### DIFF
--- a/digitisation/k4run/digi_steer.py
+++ b/digitisation/k4run/digi_steer.py
@@ -1,3 +1,4 @@
+import os
 from Gaudi.Configuration import *
 
 from Configurables import LcioEvent, EventDataSvc, MarlinProcessorWrapper
@@ -14,7 +15,7 @@ DD4hep = MarlinProcessorWrapper("DD4hep")
 DD4hep.OutputLevel = INFO
 DD4hep.ProcessorType = "InitializeDD4hep"
 DD4hep.Parameters = {
-                     "DD4hepXMLFile": ["/path/to/compact/geometry/file.xml"],
+                     "DD4hepXMLFile": [os.environ.get("MUCOLL_GEO")],
                      "EncodingStringParameterName": ["GlobalTrackerReadoutID"]
                      }
 

--- a/reconstruction/k4run/reco_steer.py
+++ b/reconstruction/k4run/reco_steer.py
@@ -1,3 +1,4 @@
+import os
 from Gaudi.Configuration import *
 
 from Configurables import LcioEvent, EventDataSvc, MarlinProcessorWrapper
@@ -15,7 +16,7 @@ DD4hep = MarlinProcessorWrapper("DD4hep")
 DD4hep.OutputLevel = INFO
 DD4hep.ProcessorType = "InitializeDD4hep"
 DD4hep.Parameters = {
-                     "DD4hepXMLFile": ["/path/to/compact/geometry/file.xml"],
+                     "DD4hepXMLFile": [os.environ.get("MUCOLL_GEO")],
                      "EncodingStringParameterName": ["GlobalTrackerReadoutID"]
                      }
 


### PR DESCRIPTION
Hi @madbaron @bartosik-hep ,

What do you think about steering the new config files with `os.environ.get("MUCOLL_GEO")`, in the same style as simulation/ilcsoft/steer_baseline.py ?

https://github.com/MuonColliderSoft/mucoll-benchmarks/blob/main/simulation/ilcsoft/steer_baseline.py#L9
