### PR TITLE
Update TrackerHitCollectionNames to match digi_steer.py

### DIFF
--- a/reconstruction/k4run/reco_steer.py
+++ b/reconstruction/k4run/reco_steer.py
@@ -100,7 +100,7 @@ CKFTracking.Parameters = {
         ],
     "TGeoFile": ["/path/to/tgeo.root"],
     "TrackCollectionName": ["AllTracks"],
-    "TrackerHitCollectionNames": ["VBTrackerHits", "IBTrackerHits", "OBTrackerHits", "VETrackerHits", "IETrackerHits", "OETrackerHits"],
+    "TrackerHitCollectionNames": ["VXDBarrelHits", "ITBarrelHits", "OTBarrelHits", "VXDEndcapHits", "ITEndcapHits", "OTEndcapHits"],
     "CaloFace_Radius": ["1500"],
     "CaloFace_Z": ["2307"]
 }


### PR DESCRIPTION
Hi again @madbaron @bartosik-hep ,

I think there's a mismatch between tracker hit names in `digi_steer.py` and `reco_steer.py`. I'm not sure what's the preferred naming convention (e.g. VXDBarrelHits vs VBTrackerHits), but here's a PR for changing `reco_steer.py`.