### PR TITLE
Add seed option to pgun gen scripts.

### DIFF
--- a/generation/pgun/pgun_edm4hep.py
+++ b/generation/pgun/pgun_edm4hep.py
@@ -13,6 +13,7 @@ import argparse
 
 parser = argparse.ArgumentParser(description='Generate LCIO::MCParticles with specified parameters')
 parser.add_argument('output', metavar='FILE_OUT.slcio', help='Output LCIO file')
+parser.add_argument('-s', '--seed', metavar='seed', type=int, help='Seed to use for random generator', default=12345)
 parser.add_argument('-c', '--comment', metavar='TEXT',  help='Comment to be added to the run header', type=str)
 parser.add_argument('-e', '--events', metavar='N', type=int, default=1,  help='Generate N events')
 parser.add_argument('-p', '--particles', metavar='N', type=int, default=1,  help='Generate N particles/event')
@@ -49,7 +50,7 @@ for pdg in args.pdg:
 
 # Generating sampling distributions for each property (1 value/event)
 sample_size = args.events
-rng = np.random.default_rng(12345)
+rng = np.random.default_rng(args.seed)
 samples = {}
 configs = {
 	'dt': args.dt,

--- a/generation/pgun/pgun_lcio.py
+++ b/generation/pgun/pgun_lcio.py
@@ -13,6 +13,7 @@ import argparse
 
 parser = argparse.ArgumentParser(description='Generate LCIO::MCParticles with specified parameters')
 parser.add_argument('output', metavar='FILE_OUT.slcio', help='Output LCIO file')
+parser.add_argument('-s', '--seed', metavar='seed', type=int, help='Seed to use for random generator', default=12345)
 parser.add_argument('-c', '--comment', metavar='TEXT',  help='Comment to be added to the run header', type=str)
 parser.add_argument('-e', '--events', metavar='N', type=int, default=1,  help='# of events to generate (default: 1)')
 parser.add_argument('-p', '--particles', metavar='N', type=int, default=1,  help='# of particles/event to generate (default: 1)')
@@ -47,7 +48,7 @@ for pdg in args.pdg:
 
 # Generating sampling distributions for each property (1 value/event)
 sample_size = args.events * args.particles
-rng = np.random.default_rng(12345)
+rng = np.random.default_rng(args.seed)
 samples = {}
 configs = {
 	'dt': args.dt,


### PR DESCRIPTION
Both the `pgun_lcio.py` and `pgun_edm4hep.py` scripts now take an `--seed`/`-s` argument that is used to initialize the random number generator.

This makes it possible to generate samples split into multiple files that are statistically independent.