### PR TITLE
Changing EvtMax from 10 to -1 to run on all events

### DIFF
--- a/digitisation/k4run/digi_steer.py
+++ b/digitisation/k4run/digi_steer.py
@@ -566,7 +566,7 @@ algList.append(LCIOWriter_light)
 from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = algList,
                 EvtSel = 'NONE',
-                EvtMax   = 10,
+                EvtMax   = -1,
                 ExtSvc = [evtsvc],
                 OutputLevel=INFO
               )

--- a/reconstruction/k4run/reco_steer.py
+++ b/reconstruction/k4run/reco_steer.py
@@ -316,7 +316,7 @@ algList.append(LCIOWriter_light)
 from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg = algList,
                 EvtSel = 'NONE',
-                EvtMax   = 10,
+                EvtMax   = -1,
                 ExtSvc = [evtsvc],
                 OutputLevel=INFO
               )


### PR DESCRIPTION
To enable running on all events in the digitization and reconstruction step.