### PR TITLE
Use the `--dt` command-line arg to set time

### DIFF
--- a/generation/pgun/pgun_lcio.py
+++ b/generation/pgun/pgun_lcio.py
@@ -117,6 +117,7 @@ for e in range(args.events):
 		# Calculating all properties for this particle in the event
 		theta = samples['theta'][s]
 		phi = samples['phi'][s]
+		dt = samples['dt'][s]
 		# Calculating momentum vector
 		if 'pt' in configs:
 			pt = samples['pt'][s]
@@ -142,6 +143,7 @@ for e in range(args.events):
 		mcp.setPDG(pdg)
 		mcp.setMomentum(momentum)
 		mcp.setVertex(vtx)
+		mcp.setTime(dt)
 		# Adding particle to the event
 		col.addElement(mcp)
 		n_particles += 1


### PR DESCRIPTION
As a followup to: https://github.com/MuonColliderSoft/mucoll-benchmarks/issues/18, which was noticed at the software tutorial today.

cc @kakwok
