### PR TITLE
Updating fluka_to_edm4hep.py

### DIFF
--- a/generation/bib/fluka_to_edm4hep.py
+++ b/generation/bib/fluka_to_edm4hep.py
@@ -6,13 +6,13 @@ import argparse
 import numpy as np
 
 
-parser = argparse.ArgumentParser(description='Convert FLUKA binary file to SLCIO file with MCParticles')
+parser = argparse.ArgumentParser(description='Convert FLUKA binary file to EDM4HEP file with MCParticles')
 parser.add_argument('files_in', metavar='FILE_IN', help='Input binary FLUKA file(s)', nargs='+')
 parser.add_argument('file_out', metavar='FILE_OUT.edm4hep.root', help='Output EDM4HEP file')
 parser.add_argument('-c', '--comment', metavar='TEXT',  help='Comment to be added to the header', type=str)
 parser.add_argument('-b', '--bx_time', metavar='TIME',  help='Time of the bunch crossing [s]', type=float, default=0.0)
 parser.add_argument('-n', '--normalization', metavar='N',  help='Normalization of the generated sample', type=float, default=1.0)
-parser.add_argument('-f', '--files_event', metavar='L',  help='Number of files to merge into a single LCIO event (default: 1)', type=int, default=1)
+parser.add_argument('-f', '--files_event', metavar='L',  help='Number of files to merge into a single EDM4HEP event (default: 1)', type=int, default=1)
 parser.add_argument('-m', '--max_lines', metavar='M',  help='Maximum number of lines to process', type=int, default=None)
 parser.add_argument('-o', '--overwrite',  help='Overwrite existing output file', action='store_true', default=False)
 parser.add_argument('-z', '--invert_z', help='Invert Z position and Z momentum (use for the second beam direction)', action='store_true', default=False)

--- a/generation/bib/fluka_to_edm4hep.py
+++ b/generation/bib/fluka_to_edm4hep.py
@@ -16,8 +16,6 @@ parser.add_argument('-f', '--files_event', metavar='L',  help='Number of files t
 parser.add_argument('-m', '--max_lines', metavar='M',  help='Maximum number of lines to process', type=int, default=None)
 parser.add_argument('-o', '--overwrite',  help='Overwrite existing output file', action='store_true', default=False)
 parser.add_argument('-z', '--invert_z', help='Invert Z position and Z momentum (use for the second beam direction)', action='store_true', default=False)
-parser.add_argument('--pdgs', metavar='ID',  help='PDG IDs of particles to be included', type=int, default=None, nargs='+')
-parser.add_argument('--nopdgs', metavar='ID',  help='PDG IDs of particles to be excluded', type=int, default=None, nargs='+')
 parser.add_argument('--np_min', metavar='P',  help='Minimum momentum of accepted neutrons [GeV]', type=float, default=None)
 parser.add_argument('--t_max', metavar='T',  help='Maximum time of accepted particles [ns]', type=float, default=None)
 
@@ -137,12 +135,6 @@ for iF, file_in in enumerate(args.files_in):
 			pdg = FLUKA_PIDS[fid]
 		except KeyError:
 			print(f'WARNING: Unknown PDG ID for FLUKA ID: {fid}')
-			continue
-
-		# Apply PDG filters for BIB pruning
-		if args.pdgs is not None and pdg not in args.pdgs:
-			continue
-		if args.nopdgs is not None and pdg in args.nopdgs:
 			continue
 
 		# Calculating the absolute time of the particle [ns]

--- a/generation/bib/fluka_to_edm4hep.py
+++ b/generation/bib/fluka_to_edm4hep.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""This script converts a FLUKA binary file to an SLCIO file with LCIO::MCParticle instances"""
+"""Convert a FLUKA binary file to an EDM4HEP file with MCParticle instances."""
 
 import os
 import argparse
@@ -8,16 +8,17 @@ import numpy as np
 
 parser = argparse.ArgumentParser(description='Convert FLUKA binary file to SLCIO file with MCParticles')
 parser.add_argument('files_in', metavar='FILE_IN', help='Input binary FLUKA file(s)', nargs='+')
-parser.add_argument('file_out', metavar='FILE_OUT.slcio', help='Output SLCIO file')
+parser.add_argument('file_out', metavar='FILE_OUT.edm4hep.root', help='Output EDM4HEP file')
 parser.add_argument('-c', '--comment', metavar='TEXT',  help='Comment to be added to the header', type=str)
 parser.add_argument('-b', '--bx_time', metavar='TIME',  help='Time of the bunch crossing [s]', type=float, default=0.0)
 parser.add_argument('-n', '--normalization', metavar='N',  help='Normalization of the generated sample', type=float, default=1.0)
 parser.add_argument('-f', '--files_event', metavar='L',  help='Number of files to merge into a single LCIO event (default: 1)', type=int, default=1)
 parser.add_argument('-m', '--max_lines', metavar='M',  help='Maximum number of lines to process', type=int, default=None)
 parser.add_argument('-o', '--overwrite',  help='Overwrite existing output file', action='store_true', default=False)
+parser.add_argument('-z', '--invert_z', help='Invert Z position and Z momentum (use for the second beam direction)', action='store_true', default=False)
 parser.add_argument('--pdgs', metavar='ID',  help='PDG IDs of particles to be included', type=int, default=None, nargs='+')
 parser.add_argument('--nopdgs', metavar='ID',  help='PDG IDs of particles to be excluded', type=int, default=None, nargs='+')
-parser.add_argument('--ne_min', metavar='E',  help='Minimum energy of accepted neutrons [GeV]', type=float, default=None)
+parser.add_argument('--np_min', metavar='P',  help='Minimum momentum of accepted neutrons [GeV]', type=float, default=None)
 parser.add_argument('--t_max', metavar='T',  help='Maximum time of accepted particles [ns]', type=float, default=None)
 
 args = parser.parse_args()
@@ -26,12 +27,8 @@ if not args.overwrite and os.path.isfile(args.file_out):
 	raise FileExistsError(f'Output file already exists: {args.file_out:s}')
 
 
-from math import sqrt
-from pdb import set_trace as br
-from array import array
-
-from edm4hep import edm4hep
-from ROOT import podio
+import edm4hep
+import podio
 from podio.root_io import Writer
 import cppyy
 
@@ -49,7 +46,7 @@ def bytes_from_file(filename):
 				return
 			yield chunk
 
-# Binary format of a single entry
+# Binary format of a single entry, as specified in data_formats.py
 line_dt=np.dtype([
 	('fid',  np.int32),
 	('fid_mo',  np.int32),
@@ -61,7 +58,6 @@ line_dt=np.dtype([
 	('cy', np.float64),
 	('cz', np.float64),
 	('age', np.float64),
-	('age_mu', np.float64),
 	('x_mu', np.float64),
 	('y_mu', np.float64),
 	('z_mu', np.float64),
@@ -75,7 +71,7 @@ line_dt=np.dtype([
 ])
 
 ######################################## Start of the processing
-print(f'Converting data from {len(args.files_in)} file(s)\nto SLCIO file: {args.file_out:s}\nwith normalization: {args.normalization:.1f}')
+print(f'Converting data from {len(args.files_in)} file(s)\nto EDM4HEP file: {args.file_out:s}\nwith normalization: {args.normalization:.1f}')
 print(f'Storing {args.files_event:d} files/event');
 if args.pdgs is not None:
 	print(f'Will only use particles with PDG IDs: {args.pdgs}')
@@ -85,23 +81,25 @@ writer = Writer(args.file_out)
 
 # Write a RunHeader
 frame = podio.Frame()
-frame.putParameter("InputFiles", len(args.files_in))
-frame.putParameter("Normalization", str(args.normalization))
-frame.putParameter("BXTime", str(args.bx_time))
-frame.putParameter("FilesPerEvent", str(args.files_event))
+frame.put_parameter("InputFiles", len(args.files_in))
+frame.put_parameter("Normalization", str(args.normalization))
+frame.put_parameter("BXTime", str(args.bx_time))
+frame.put_parameter("FilesPerEvent", str(args.files_event))
 
 if args.t_max:
-	frame.putParameter("Time_max", str(args.t_max))
-if args.ne_min:
-	frame.putParameter("NeutronEnergy_min", str(args.ne_min))
+	frame.put_parameter("Time_max", str(args.t_max))
+if args.np_min:
+	frame.put_parameter("NeutronMomentum_min", str(args.np_min))
 if args.pdgs:
-	frame.putParameter("PdgIds", str(args.pdgs))
+	frame.put_parameter("PdgIds", str(args.pdgs))
 if args.nopdgs:
-	frame.putParameter("NoPdgIds", str(args.nopdgs))
+	frame.put_parameter("NoPdgIds", str(args.nopdgs))
 if args.comment:
-	frame.putParameter("Comment", str(args.comment))
+	frame.put_parameter("Comment", str(args.comment))
+if args.invert_z:
+	frame.put_parameter("InvertZ", "True")
 
-writer.writeFrame(frame, 'header')
+writer.write_frame(frame, 'header')
 	
 # Bookkeeping variables
 random.seed()
@@ -117,18 +115,19 @@ for iF, file_in in enumerate(args.files_in):
 	if nEventFiles == 0:
 		col = edm4hep.MCParticleCollection()
 		evt = podio.Frame()
-		evt.putParameter("eventNumber", str(nEvents))
+		evt.put_parameter("eventNumber", str(nEvents))
 
 
 	# Looping over particles from the file
 	for iL, data in enumerate(bytes_from_file(file_in)):
 		if args.max_lines and nLines >= args.max_lines:
 			break
+		nLines += 1
 
 		# Extracting relevant values from the line
-		fid,e, x,y,z, cx,cy,cz, toff,toff_mo = (data[n][0] for n in [
+		fid, e, x, y, z, cx, cy, cz, toff, toff_mo = (data[n][0] for n in [
 			'fid', 'E',
-			'x','y','z',
+			'x', 'y', 'z',
 			'cx', 'cy', 'cz',
 			'age', 'age_mo'
 		])
@@ -140,6 +139,12 @@ for iF, file_in in enumerate(args.files_in):
 			print(f'WARNING: Unknown PDG ID for FLUKA ID: {fid}')
 			continue
 
+		# Apply PDG filters for BIB pruning
+		if args.pdgs is not None and pdg not in args.pdgs:
+			continue
+		if args.nopdgs is not None and pdg in args.nopdgs:
+			continue
+
 		# Calculating the absolute time of the particle [ns]
 		t = (toff - toff_mo - args.bx_time) * 1e9
 
@@ -147,61 +152,68 @@ for iF, file_in in enumerate(args.files_in):
 		if args.t_max is not None and t > args.t_max:
 			continue
 
-		# Calculating the components of the momentum vector
-		mom = np.array([cx, cy, cz], dtype=np.float32)
-		mom *= e
-
-		# Skipping if it's a neutron with too low kinetic energy
-		if args.ne_min is not None and abs(pdg) == 2112 and np.linalg.norm(mom) < args.ne_min:
-			continue
-
 		# Getting the charge and mass of the particle
 		if pdg not in PDG_PROPS:
 			print('WARNING! No properties defined for PDG ID: {0:d}'.format(pdg))
-			print('         Skpping the particle...')
+			print('         Skipping the particle...')
 			continue
 		charge, mass = PDG_PROPS[pdg]
+
+		# Calculating the total momentum from the kinetic energy [GeV]
+		mom_tot = math.sqrt(e**2 + 2 * e * mass)
+
+		# Skipping if it's a neutron with too low momentum
+		if args.np_min is not None and abs(pdg) == 2112 and mom_tot < args.np_min:
+			continue
+
+		# Calculating the components of the momentum vector [GeV]
+		mom = np.array([cx, cy, cz], dtype=np.float32) * mom_tot
 
 		# Calculating how many random copies of the particle to create according to the weight
 		nP_frac, nP = math.modf(args.normalization)
 		if nP_frac > 0 and random.random() < nP_frac:
 			nP += 1
 		nP = int(nP)
-		
-		# Creating the particle with original parameters
-		#particle = edm4hep.MutableMCParticle() 
-		particle = col.create()
-		particle.setPDG(pdg)
-		particle.setGeneratorStatus(1)
-		particle.setTime(t)
-		particle.setMass(mass)
-		particle.setCharge(charge)
-		pos = np.array([x, y, z], dtype=np.float64)
 
-		# Creating the particle copies with random Phi rotation
-		px, py, pz = mom
-		for i, iP in enumerate(range(nP)):
-			# Rotating position and momentum of the copies by a random angle in Phi
-			if i > 0:
+		# Convert position from cm (FLUKA) to mm (EDM4HEP)
+		x_mm, y_mm, z_mm = x * 10.0, y * 10.0, z * 10.0
+		px, py, pz = float(mom[0]), float(mom[1]), float(mom[2])
+
+		if args.invert_z:
+			z_mm *= -1
+			pz   *= -1
+
+		# Create one collection entry per copy, each with a random Phi rotation
+		for iP in range(nP):
+			cur_x, cur_y, cur_z = x_mm, y_mm, z_mm
+			cur_px, cur_py, cur_pz = px, py, pz
+			if nP > 1:
 				dPhi = random.random() * math.pi * 2
 				co = math.cos(dPhi)
 				si = math.sin(dPhi)
-				pos[0] = co * x - si * y
-				pos[1] = si * x + co * y
-				mom[0] = co * px - si * py
-				mom[1] = si * px + co * py
-			particle.setVertex(pos)
-			particle.setMomentum(mom)
+				cur_x = co * x_mm - si * y_mm
+				cur_y = si * x_mm + co * y_mm
+				cur_px = co * px - si * py
+				cur_py = si * px + co * py
+			particle = col.create()
+			particle.setPDG(pdg)
+			particle.setGeneratorStatus(1)
+			particle.setTime(t)
+			particle.setMass(mass)
+			particle.setCharge(charge)
+			particle.setVertex(edm4hep.Vector3d(cur_x, cur_y, cur_z))
+			particle.setMomentum(edm4hep.Vector3d(cur_px, cur_py, cur_pz))
 
 	# Updating counters
 	nEventFiles += 1
 	if nEventFiles >= args.files_event or iF+1 == len(args.files_in):
-		nEvents +=1
+		nEvents += 1
 		nEventFiles = 0
-		evt.put(cppyy.gbl.std.move(col), "MCParticles")	
-		writer.writeFrame(evt, 'events')
-		print(f'Wrote event: {nEvents:d} with {col.size()} particles')
+		n_particles = col.size()  # save before move invalidates col
+		evt.put(cppyy.gbl.std.move(col), "MCParticles")
+		writer.write_frame(evt, 'events')
+		print(f'Wrote event: {nEvents:d} with {n_particles} particles')
 	
 print(f'Wrote {nEvents:d} events to file: {args.file_out:s}')
 
-writer.finish()
+writer._writer.finish()

--- a/generation/bib/fluka_to_edm4hep.py
+++ b/generation/bib/fluka_to_edm4hep.py
@@ -71,8 +71,6 @@ line_dt=np.dtype([
 ######################################## Start of the processing
 print(f'Converting data from {len(args.files_in)} file(s)\nto EDM4HEP file: {args.file_out:s}\nwith normalization: {args.normalization:.1f}')
 print(f'Storing {args.files_event:d} files/event');
-if args.pdgs is not None:
-	print(f'Will only use particles with PDG IDs: {args.pdgs}')
 
 # Initialize the EDM4HEP file writer
 writer = Writer(args.file_out)
@@ -88,10 +86,6 @@ if args.t_max:
 	frame.put_parameter("Time_max", str(args.t_max))
 if args.np_min:
 	frame.put_parameter("NeutronMomentum_min", str(args.np_min))
-if args.pdgs:
-	frame.put_parameter("PdgIds", str(args.pdgs))
-if args.nopdgs:
-	frame.put_parameter("NoPdgIds", str(args.nopdgs))
 if args.comment:
 	frame.put_parameter("Comment", str(args.comment))
 if args.invert_z:


### PR DESCRIPTION
This PR updates several items in `generation/bib/fluka_to_edm4hep.py`, either for correctness or to align it with `fluka_to_slcio.py` more closely. I am testing this version of the script locally and am happy to provide any validation that would be useful.

  - Added `-z` option to invert BIB (for `MUPLUS` vs. `MUMINUS`), which was missing in this script.
  - Removed `age_mu` from the record dtype, as it was no longer included in `1` in `data_formats.py`
  - Adjusted `ne_min` argument to be `np_min` matching `fluka_to_slcio.py` (neutron minimum momentum)
  - Removed references to slcio throughout
